### PR TITLE
カスタム属性[Toolbar]の実装

### DIFF
--- a/CASE_MainProject/Assets/Editor/ToolbarDrawer.cs
+++ b/CASE_MainProject/Assets/Editor/ToolbarDrawer.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+#if UNITY_EDITOR
+
+using UnityEditor;
+
+#endif
+
+#if UNITY_EDITOR
+[CustomPropertyDrawer(typeof(ToolbarAttribute))]
+public class ToolbarDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        // プロパティのエディタレイアウトの設定
+        label = EditorGUI.BeginProperty(position, label, property);
+
+        switch (property.propertyType)
+        {
+            case SerializedPropertyType.Integer: IntergerToolbar(position, property, label); break;
+            case SerializedPropertyType.Enum: EnumToolbar(position, property, label); break;
+        }
+        // 設定終了
+        EditorGUI.EndProperty();
+    }
+
+    void IntergerToolbar(Rect position, SerializedProperty property, GUIContent label)
+    {
+        ToolbarAttribute toolbar = attribute as ToolbarAttribute;
+        EditorGUI.BeginChangeCheck();
+
+        int newIndex = GUI.Toolbar(position, property.intValue, toolbar.labels);
+
+        if(EditorGUI.EndChangeCheck())
+        {
+            property.intValue = newIndex;
+            InvokeMethod(property, newIndex);
+        }
+    }
+
+    void EnumToolbar(Rect position, SerializedProperty property, GUIContent label)
+    {
+        ToolbarAttribute toolbar = attribute as ToolbarAttribute;
+        EditorGUI.BeginChangeCheck();
+
+        int newIndex = GUI.Toolbar(position, property.enumValueIndex, GetInspectorNames());
+
+        if(EditorGUI.EndChangeCheck())
+        {
+            property.enumValueIndex = newIndex;
+            InvokeMethod(property, newIndex);
+        }
+    }
+
+    void InvokeMethod(SerializedProperty property, object parameter)
+    {
+        ToolbarAttribute toolbar = attribute as ToolbarAttribute;
+        if(!string.IsNullOrEmpty(toolbar.method))
+        {
+            object obj = property.serializedObject.targetObject;
+            MethodInfo method = obj.GetType().GetMethod(toolbar.method, BindingFlags.Public | BindingFlags.Instance);
+            method.Invoke(obj, new[] { parameter });
+        }
+    }
+
+    string[] GetInspectorNames()
+    {
+        ToolbarAttribute toolbar = attribute as ToolbarAttribute;
+        Dictionary<string, string> result = new Dictionary<string, string>();
+        string[] names = toolbar.type.GetEnumNames();
+        foreach(string name in names)
+        {
+            result.Add(name, name);
+        }
+
+        FieldInfo[] fields = toolbar.type.GetFields();
+        foreach(FieldInfo field in fields)
+        {
+            var inspectorName = Attribute.GetCustomAttribute(field, typeof(InspectorNameAttribute)) as InspectorNameAttribute;
+            if(inspectorName != null)
+            {
+                if(result.ContainsKey(field.Name))
+                {
+                    result[field.Name] = inspectorName.displayName;
+                }
+            }
+        }
+        return result.Values.ToArray();
+    }
+}
+#endif

--- a/CASE_MainProject/Assets/Editor/ToolbarDrawer.cs.meta
+++ b/CASE_MainProject/Assets/Editor/ToolbarDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd139f173cc72d14ca950b6e78270989
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CASE_MainProject/Assets/EditorTool/ToolbarAttribute.cs
+++ b/CASE_MainProject/Assets/EditorTool/ToolbarAttribute.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using System;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class ToolbarAttribute : PropertyAttribute
+{
+    // 文字列格納用
+    public readonly string[] labels;
+    public readonly Type type;
+    // コールバック名(選択時に関数を呼び出せる)
+    public readonly string method;
+
+    public ToolbarAttribute(string[] labels, string method = null)
+    {
+        this.labels = labels;
+        type = null;
+        this.method = method;
+    }
+
+    public ToolbarAttribute(Type type, string method = null)
+    {
+        labels = null;
+        this.type = type;
+        this.method = method;
+    }
+}

--- a/CASE_MainProject/Assets/EditorTool/ToolbarAttribute.cs.meta
+++ b/CASE_MainProject/Assets/EditorTool/ToolbarAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffd201dd6583e214591f3e562baba870
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
実装内容
---
配列や列挙型をボタンで選択できる

呼び出し
配列の場合
[Toolbar(new[]{"nameA", "nameB", "nameC"}, "任意の関数名(なしでも可)")]

列挙型の場合
enum SampleEnum
{StateA, StateB,StateC};
[Toolbar(typeof(SampleEnum), "任意の関数名(なしでも可)")]