### PR TITLE
Enemy_TypeCの実装(途中)

### DIFF
--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Bullet.prefab
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Bullet.prefab
@@ -1,0 +1,135 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6806269914522788958
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7447798538433440374}
+  - component: {fileID: 8837135549692361000}
+  - component: {fileID: 3434653421372372111}
+  - component: {fileID: 4017858934112127040}
+  - component: {fileID: 4550546400231991449}
+  m_Layer: 0
+  m_Name: Bullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7447798538433440374
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6806269914522788958}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8837135549692361000
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6806269914522788958}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3434653421372372111
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6806269914522788958}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &4017858934112127040
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6806269914522788958}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &4550546400231991449
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6806269914522788958}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 112
+  m_CollisionDetection: 0

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Bullet.prefab.meta
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Bullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8d054d3b4a0136b49b065b8924f06586
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_Mob.cs
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_Mob.cs
@@ -17,8 +17,18 @@ public abstract class Enemy_Mob : Enemy_Parent
         [InspectorName("回復")] Heal,
         [InspectorName("破壊")] Death,
     }
+
+    [SerializeField, Header("敵視認距離")]
+    protected float viewingDistance = 20.0f;
+
+    [SerializeField, Header("視野角")]
+    protected float viewingAngle = 80.0f;
+
+    [SerializeField, Header("視点の高さ")]
+    protected float eyeHeight = 1.0f;
+
     [SerializeField, Header("状態"), Toolbar(typeof(State))]
-    State state = State.Idle;
+    protected State state = State.Idle;
     
     protected void Start()
     {
@@ -147,5 +157,51 @@ public abstract class Enemy_Mob : Enemy_Parent
     protected override void DestroyFunc()
     {
 
+    }
+
+    /*
+     * <summary>
+     * プレイヤーを視野角を元に探す処理
+     * <param>
+     * なし
+     * <returns>
+     * bool isFind, float distance
+     */
+    protected (bool isFind, float distance) FindPlayerAtFOV()
+    {
+        // 距離を測る
+        float distance = Vector3.Distance(target.transform.position, transform.position);
+
+        if (distance < viewingDistance)
+        {
+            // 自分からターゲットに向かうベクトル
+            Vector3 MetoTarget = target.transform.position - transform.position;
+            // ターゲットから自分に向かうベクトル
+            Vector3 TargettoMe = -MetoTarget;
+            // 外積でy軸から正面の左右どちらにあるか求める
+            Vector3 axis = Vector3.Cross(transform.forward, MetoTarget);
+
+            // 角度が+なら正面より右にいる-なら左にいる
+            float angle = Vector3.Angle(transform.forward, MetoTarget) * (axis.y < 0 ? -1.0f : 1.0f);
+
+            if (Mathf.Abs(angle) < viewingAngle / 2)
+            {
+                Vector3 Direction = MetoTarget.normalized;
+                // 目の位置を決める
+                Vector3 eyePos = transform.position + new Vector3(0.0f, eyeHeight, 0.0f);
+                // 例の作成と表示
+                Ray ray = new Ray(eyePos, Direction);
+                Debug.DrawRay(eyePos, Direction, Color.red);
+                RaycastHit[] hits = Physics.RaycastAll(eyePos, Direction, viewingDistance);
+                if (hits.Length > 0)
+                {
+                    if (hits[0].transform.tag == "Player")
+                    {
+                        return (true, distance);
+                    }
+                }
+            }
+        }
+        return (false, distance);
     }
 }

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_Parent.cs
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_Parent.cs
@@ -10,6 +10,13 @@ public abstract class Enemy_Parent : MonoBehaviour
         [InspectorName("ボス")]Boss
     };
 
+    public struct EnemySetting
+    {
+        public EnemyType type;
+        public float hp;
+        public float pressure;
+    }
+
     [SerializeField, Header("敵タイプ"), Toolbar(typeof(EnemyType))]
     protected EnemyType enemyType;
 
@@ -32,19 +39,18 @@ public abstract class Enemy_Parent : MonoBehaviour
             target = GameObject.Find("Player");
             if(target != null)
             {
-                Debug.Log("見つけた");
+                Debug.Log("Playerの格納完了");
             }
         }
 
         currentHp = maxHp;
         currentPressure = maxPressure;
-        Debug.Log("開始");
     }
 
     // Update is called once per frame
     protected void Update()
     {
-        Debug.Log("更新");
+
     }
 
     /*
@@ -55,7 +61,7 @@ public abstract class Enemy_Parent : MonoBehaviour
      * <retrun>
      * なし
      */
-    public void Damage(float val)
+    public virtual void Damage(float val)
     {
         currentHp -= val;
         DestroyCheck();
@@ -87,4 +93,5 @@ public abstract class Enemy_Parent : MonoBehaviour
      * なし
      */
     protected abstract void DestroyFunc();
+
 }

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.cs
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.cs
@@ -1,0 +1,256 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Enemy_TypeC : Enemy_Mob
+{
+    const float pad = 20.0f;
+
+    [Space(pad), Header("--インターバル--")]
+    [SerializeField, Header("待機インターバル")]
+    float waitInterval;
+    [SerializeField, Header("移動インターバル")]
+    float moveInterval;
+    [SerializeField, Header("近距離攻撃インターバル")]
+    float closeInterval;
+    [SerializeField, Header("遠距離攻撃インターバル")]
+    float rangedInterval;
+
+    [Space(pad), Header("--メインパラメータ--")]
+
+    [SerializeField, Header("汎用カウント"), ReadOnly]
+    float cnt;
+    [SerializeField, Header("回転速度"), Range(0.0f, 1.0f)]
+    float rotationRate = 0.3f;
+    [SerializeField, Header("移動速度"), Range(0.0f, 30.0f)]
+    float moveSpeed = 5.0f;
+    [SerializeField, Header("移動時の消費圧力"), Range(0.0f, 20.0f)]
+    float pressureForMove = 2.0f;
+    [SerializeField, Header("追撃時の移動倍率"), Range(1.0f, 10.0f)]
+    float trackingSpeedRate = 1.5f;
+    [SerializeField, Header("回復に移行する圧力量")]
+    float pressureForHealMode = 15.0f;
+    [SerializeField, Header("1秒当たりの圧力回復量")]
+    float pressurePerHeal = 5.0f;
+    [SerializeField, Header("回復から復帰する圧力量")]
+    float pressureForStoppedHeal = 50.0f;
+
+    [Space(pad), Header("--遠距離攻撃--")]
+
+    [SerializeField, Header("遷移距離")]
+    float distanceForRangedAttack = 12.0f;
+    [SerializeField, Header("消費圧力")]
+    float pressureForRangedAttack = 5.0f;
+    [SerializeField, Header("最低必要圧力")]
+    float lineForRagnedAttack = 10.0f;
+    [SerializeField, Header("遠距離攻撃の弾")]
+    GameObject objectForRangedAttack;
+    [SerializeField, Header("遠距離攻撃の速度")]
+    float rangedAttackSpeed;
+
+    [Space(pad), Header("--近距離攻撃--")]
+
+    [SerializeField, Header("遷移距離")]
+    float distanceForCloseAttack = 5.0f;
+    [SerializeField, Header("消費圧力")]
+    float pressureForCloseAttack = 2.0f;
+    [SerializeField, Header("最低必要圧力")]
+    float lineForCloseAttack = 7.0f;
+
+    [Space(pad), Header("--パトロール関連--")]
+
+    [SerializeField, Header("パトロールコンポーネント"), ReadOnly]
+    Patrol patrol;
+    [SerializeField, Header("目的地数"),ReadOnly]
+    int targetNum = 0;
+    [SerializeField, Header("目的地のインデックス"), ReadOnly]
+    int targetIndex = 0;
+    [SerializeField, Header("次の目的地"), ReadOnly]
+    Vector3 nextTargetPos;
+
+    void Start()
+    {
+        base.Start();
+        patrol = GetComponent<Patrol>();
+        targetNum = patrol.GetTargets().Length;
+        nextTargetPos = patrol.GetTargets()[0].position;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        base.Update();
+    }
+
+    protected override void IdleFunc()
+    {
+        cnt += Time.deltaTime;
+        (bool isFind, float distance) = FindPlayerAtFOV();
+
+        // 追尾モードに移行
+        if (isFind)
+        {
+            cnt = 0.0f;
+            state = State.Tracking;
+        }
+
+        // プレイヤーの方向へ少しずつ回転
+        //Vector3 targetVector = target.transform.position - transform.position;
+        //Vector3 axis = Vector3.Cross(transform.forward, targetVector);
+        //float angle = Vector3.Angle(transform.forward, targetVector) * (axis.y < 0 ? -1.0f : 1.0f);
+        //angle = Mathf.Lerp(0.0f, angle, rotationRate);
+        //transform.Rotate(0.0f, angle * Time.deltaTime, 0.0f);
+
+
+        // 次の目的地へ回転
+        Vector3 targetVector = nextTargetPos - transform.position;
+        Vector3 axis = Vector3.Cross(transform.forward, targetVector);
+        float angle = Vector3.Angle(transform.forward, targetVector) * (axis.y < 0 ? -1.0f : 1.0f);
+        angle = Mathf.Lerp(0.0f, angle, cnt / waitInterval) * 0.1f;
+        transform.Rotate(0.0f, angle, 0.0f);
+
+        // 移動モードに移行
+        if (cnt > waitInterval)
+        {
+            cnt = 0.0f;
+            state = State.Move;
+            patrol.SetInitPosition(transform.position, moveSpeed, targetIndex);
+        }
+    }
+
+    protected override void MoveFunc()
+    {
+        cnt += Time.deltaTime;
+        currentPressure -= pressureForMove * Time.deltaTime;
+        // 圧力回復モードに遷移
+        if(currentPressure < pressureForHealMode)
+        {
+            state = State.Heal;
+            return;
+        }
+        (bool isFind, float distance) = FindPlayerAtFOV();
+
+        // 追尾モードに移行
+        if (isFind)
+        {
+            cnt = 0.0f;
+            state = State.Tracking;
+            return;
+        }
+        bool b = patrol.ExcutePatrol(targetIndex, moveSpeed);
+
+        // 待機モードに移行
+        if (b)
+        {
+            cnt = 0.0f;
+            state = State.Idle;
+            targetIndex++;
+            if(targetIndex >= targetNum)
+            {
+                targetIndex = 0;
+            }
+            nextTargetPos = patrol.GetTargets()[targetIndex].position;
+        }
+    }
+
+    protected override void TrackingFunc()
+    {
+        // 待機モードに移行
+        if(!FindPlayerAtFOV().isFind)
+        {
+            state = State.Idle;
+        }
+        else
+        {
+            transform.LookAt(target.transform.position);
+            transform.Translate(Vector3.forward * moveSpeed * Time.deltaTime * trackingSpeedRate);
+
+            // 攻撃モードへの遷移
+            Vector3 Diff = target.transform.position - transform.position;
+            float dis2 = Diff.x * Diff.x + Diff.y * Diff.y + Diff.z * Diff.z;
+            float range1 = distanceForCloseAttack * distanceForCloseAttack;
+            float range2 = distanceForRangedAttack * distanceForRangedAttack;
+
+            // 遠距離攻撃に重きを置く
+            if (dis2 < range2 && currentPressure > lineForRagnedAttack)
+            {
+                Debug.Log("遠距離攻撃モードに移行");
+                currentPressure -= pressureForRangedAttack;
+                // 遠距離攻撃を行うベクトル
+                Diff.Normalize();
+                GameObject bullet = Instantiate(objectForRangedAttack, transform.position + transform.forward * 1.5f, Quaternion.identity);
+                bullet.GetComponent<Rigidbody>().AddForce(Diff * rangedAttackSpeed, ForceMode.Impulse);
+
+                state = State.AttackB;
+                return;
+            }
+            else if (dis2 < range1 && currentPressure > lineForCloseAttack)
+            {
+                Debug.Log("近距離攻撃モードに移行");
+                currentPressure -= pressureForCloseAttack;
+                state = State.AttackA;
+                return;
+            }
+        }
+    }
+
+    protected override void EscapeFunc()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    protected override void AttackFunc1()
+    {
+        Debug.Log("近距離攻撃");
+    }
+
+    protected override void AttackFunc2()
+    {
+        cnt += Time.deltaTime;
+        // アニメーション終了待ち
+
+        if(cnt >= rangedInterval)
+        {
+            // 待機を行うか
+            state = State.Idle;
+            cnt = 0.0f;
+            // 再度遠距離攻撃か
+
+            // 近距離攻撃か
+
+            // 回復か
+        }
+    }
+
+    protected override void SpecialFuncA()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    protected override void SpecialFuncB()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    protected override void HealFunc()
+    {
+        cnt += Time.deltaTime;
+        currentPressure += pressurePerHeal * Time.deltaTime;
+        // 待機モードに移行
+        if(currentPressure > pressureForStoppedHeal)
+        {
+            cnt = 0.0f;
+            state = State.Idle;
+        }
+    }
+
+    protected override void DeathFunc()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    protected override void DestroyFunc()
+    {
+        base.DestroyFunc();
+    }
+}

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.cs.meta
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9998506b77ee4f245b3eb5912b783c28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.prefab
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.prefab
@@ -1,0 +1,313 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6208289547660221257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6669863804455991469}
+  - component: {fileID: 4060673024958343243}
+  - component: {fileID: 5585899467050373173}
+  - component: {fileID: 2837689451837980242}
+  m_Layer: 0
+  m_Name: Nose
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6669863804455991469
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6208289547660221257}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0.589}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7759244924121390735}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &4060673024958343243
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6208289547660221257}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5585899467050373173
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6208289547660221257}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &2837689451837980242
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6208289547660221257}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6623399672486820342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7759244924121390735}
+  - component: {fileID: 8087891385170161125}
+  - component: {fileID: 1960625943850551655}
+  - component: {fileID: 7435468481716106102}
+  - component: {fileID: 4618606057865856872}
+  - component: {fileID: 6620817425827467479}
+  - component: {fileID: 4690570145220688766}
+  m_Layer: 0
+  m_Name: Enemy_TypeC
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7759244924121390735
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623399672486820342}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6669863804455991469}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8087891385170161125
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623399672486820342}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1960625943850551655
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623399672486820342}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &7435468481716106102
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623399672486820342}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4618606057865856872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623399672486820342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f984e1560bbdaf4ebde337555bb24df, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startPosition: {x: 0, y: 0, z: 0}
+  distance: 0
+  targetParent: {fileID: 0}
+  patrols:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  time: 0
+  cnt: 0
+--- !u!114 &6620817425827467479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623399672486820342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9998506b77ee4f245b3eb5912b783c28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 0
+  maxHp: 10
+  currentHp: 0
+  maxPressure: 50
+  currentPressure: 0
+  viewingDistance: 20
+  viewingAngle: 80
+  eyeHeight: 1
+  state: 0
+  waitInterval: 3
+  moveInterval: 2
+  closeInterval: 2
+  rangedInterval: 1
+  cnt: 0
+  rotationRate: 0.3
+  moveSpeed: 5.2
+  pressureForMove: 2
+  trackingSpeedRate: 1.5
+  pressureForHealMode: 10
+  pressurePerHeal: 5
+  pressureForStoppedHeal: 35
+  distanceForRangedAttack: 12
+  pressureForRangedAttack: 5
+  lineForRagnedAttack: 10
+  objectForRangedAttack: {fileID: 6806269914522788958, guid: 8d054d3b4a0136b49b065b8924f06586,
+    type: 3}
+  rangedAttackSpeed: 20
+  distanceForCloseAttack: 5
+  pressureForCloseAttack: 2
+  lineForCloseAttack: 7
+  patrol: {fileID: 0}
+  targetNum: 0
+  targetIndex: 0
+  nextTargetPos: {x: 0, y: 0, z: 0}
+--- !u!54 &4690570145220688766
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623399672486820342}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 116
+  m_CollisionDetection: 0

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.prefab.meta
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Enemy_TypeC.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d11bb0eb3dadd404189d309b7ac76163
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Patrol.cs
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Patrol.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Patrol : MonoBehaviour
+{
+    [SerializeField, Header("移動開始位置"), ReadOnly]
+    Vector3 startPosition;
+
+    [SerializeField, Header("移動開始位置と目的地との距離"), ReadOnly]
+    float distance;
+
+    [SerializeField, Header("目的地の親")]
+    Transform targetParent;
+
+    [SerializeField, Header("目的地")]
+    Transform[] patrols;
+
+    [SerializeField, Header("かかる時間"), ReadOnly]
+    float time = 0.0f;
+    [SerializeField, Header("経過時間"), ReadOnly]
+    float cnt = 0.0f;
+
+    private void Start()
+    {
+        if(targetParent)
+        {
+            patrols = new Transform[targetParent.childCount];
+            for(int i = 0; i < targetParent.childCount; i++)
+            {
+                Transform trs = targetParent.GetChild(i);
+                patrols[i] = trs;
+            }
+        }
+    }
+
+    public bool ExcutePatrol(int index, float moveSpeed, bool isLook = false)
+    {
+        cnt += Time.deltaTime;
+
+        float t = cnt / time;
+        if(t >= 1.0f)
+        {
+            t = 1.0f;
+        }
+        Vector3 pos = Vector3.Lerp(startPosition, patrols[index].position, t);
+        // 向きを移動方向に向ける(強制)
+        if(isLook)
+        {
+            transform.LookAt(patrols[index].position);
+        }
+
+        transform.localPosition = pos;
+        if(t == 1.0f)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public Transform[] GetTargets()
+    {
+        return patrols;
+    }
+
+    public void SetInitPosition(Vector3 position, float moveSpeed, int index)
+    {
+        cnt = 0.0f;
+        startPosition = position;
+        distance = Vector3.Distance(startPosition, patrols[index].position);
+        time = distance / moveSpeed;
+    }
+}

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Patrol.cs.meta
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/Patrol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f984e1560bbdaf4ebde337555bb24df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/TargetPositions.prefab
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/TargetPositions.prefab
@@ -1,0 +1,193 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1668752188074562603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6333343068697062005}
+  m_Layer: 0
+  m_Name: Enemy1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6333343068697062005
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1668752188074562603}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4491697398489673217}
+  - {fileID: 5890092331025352212}
+  - {fileID: 2367609956558190303}
+  - {fileID: 7046233339871698891}
+  m_Father: {fileID: 3849945077104581188}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3192425715982918643
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3849945077104581188}
+  m_Layer: 0
+  m_Name: TargetPositions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3849945077104581188
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3192425715982918643}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6333343068697062005}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4527039976699285369
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2367609956558190303}
+  m_Layer: 0
+  m_Name: Target3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2367609956558190303
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4527039976699285369}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5, y: 0, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6333343068697062005}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4545661256164221640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7046233339871698891}
+  m_Layer: 0
+  m_Name: Target4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7046233339871698891
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4545661256164221640}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -5, y: 0, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6333343068697062005}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7442347422854701863
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5890092331025352212}
+  m_Layer: 0
+  m_Name: Target2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5890092331025352212
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7442347422854701863}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5, y: 0, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6333343068697062005}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8750393819854078363
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4491697398489673217}
+  m_Layer: 0
+  m_Name: Target1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4491697398489673217
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8750393819854078363}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5, y: 0, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6333343068697062005}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/TargetPositions.prefab.meta
+++ b/CASE_MainProject/Assets/Project/Program/GameMain/Enemy/TargetPositions.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a5abf971502eebf42b63f8ae88488ee3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
実装内容
---
**Enemy_TypeC**を途中まで実装

待機-次の目的地に向く・プレイヤーの探索
移動-次の目的地に移動・プレイヤーの探索
    └圧力一定以下で回復状態に移行
追尾-移動速度にrateをかけた速度でプレイヤーを追う
    └距離が一定以内で遠距離攻撃に必要な圧力を持っている場合遠距離攻撃(優先度/高)
    └距離が一定以内で近距離攻撃に必要な圧力を持っている場合近距離攻撃(優先度/低)
攻撃A-近距離攻撃(内容未実装)
攻撃B-遠距離攻撃、弾を発射する(インターバル1秒)
回復-圧力を回復する

**Patrol**コンポーネント
Inspectorから目的地のTransformを格納(配列)
別のコンポーネントからSetInitPositionとExcutePatrolをたたく
void SetInitPosition(Vector3 移動開始位置, float 移動速度, int 目的地の添え字)
     └移動開始位置の格納と移動にかかる時間の計算

bool ExcutePatrol(int 目的地の添え字, float 移動速度, bool(デフォルトfalse) 目的地を向くか)
     └目的地への移動(移動開始位置と目的地で補間してる)

**Enemy_TypeC**プレファブ
現段階の初期設定を適用したEnemy_TypeCのプレファブ

**TargetPositions**プレファブ
Patrolコンポーネントの最親プレファブ
1段下に各Patrolコンポーネントの目的地の親Transformを格納

**Bullet**プレファブ
Enemy_TypeCが飛ばしている弾のプレファブ
RigidBodyとSphereCollider(isTrigger = true)

変更内容
---
**Enemy_Parent**の変更内容
Damage関数を仮想関数化
**Enemy_Mob**の変更内容
変数
viewingDistance-敵視認距離
viewingAngle-視野角
eyeHeight-視点の高さ

上記3つを追加(プレイヤーを探す処理に使用)

関数
FindPlayerAtFOV(void)を追加
FindPlayerAtFOV-プレイヤーを探す処理
bool isFindとfloat distanceを返す(タプル)